### PR TITLE
Improve security in randSeq and remove unused function

### DIFF
--- a/pkg/plugin/mount.go
+++ b/pkg/plugin/mount.go
@@ -438,47 +438,6 @@ func getPVCVolumeName(pod *corev1.Pod) (string, error) {
 	return "", fmt.Errorf("failed to find volume name in the existing pod")
 }
 
-func getEphemeralContainerSettings(needsRoot bool) (string, *corev1.SecurityContext) {
-	image := Image
-	var securityContext *corev1.SecurityContext
-
-	// Define boolean pointers inline
-	allowPrivilegeEscalationTrue := true
-	allowPrivilegeEscalationFalse := false
-	readOnlyRootFilesystemTrue := true
-	runAsNonRootTrue := true
-
-	// Define seccomp profile type
-	seccompProfileRuntimeDefault := corev1.SeccompProfile{
-		Type: corev1.SeccompProfileTypeRuntimeDefault,
-	}
-
-	if needsRoot {
-		image = PrivilegedImage
-		securityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &allowPrivilegeEscalationTrue,
-			ReadOnlyRootFilesystem:   &readOnlyRootFilesystemTrue,
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"SYS_ADMIN", "SYS_CHROOT"},
-			},
-			SeccompProfile: &seccompProfileRuntimeDefault,
-		}
-	} else {
-		securityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &allowPrivilegeEscalationFalse,
-			ReadOnlyRootFilesystem:   &readOnlyRootFilesystemTrue,
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-			SeccompProfile: &seccompProfileRuntimeDefault,
-			RunAsUser:      &DefaultID,
-			RunAsGroup:     &DefaultID,
-			RunAsNonRoot:   &runAsNonRootTrue,
-		}
-	}
-	return image, securityContext
-}
-
 func getSecurityContext(needsRoot bool) *corev1.SecurityContext {
 	allowPrivilegeEscalationTrue := true
 	allowPrivilegeEscalationFalse := false

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -9,6 +9,7 @@ import (
 	"crypto/elliptic"
 
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -47,7 +48,12 @@ func randSeq(n int) string {
 	letters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		idx, err := crand.Int(crand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			b[i] = letters[rand.Intn(len(letters))]
+		} else {
+			b[i] = letters[idx.Int64()]
+		}
 	}
 	return string(b)
 }


### PR DESCRIPTION
- Use crypto/rand instead of math/rand for generating random pod/container names
- Remove unused getEphemeralContainerSettings function that duplicated getSecurityContext