### PR TITLE
ci: update vulnerability scanning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,27 @@ on:
 # test again
 
 jobs:
+  vulnerability-check:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.27.0'
+          cache: false
+
+      - name: Run vulnerability check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+          govulncheck ./...
+
   test:
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -42,11 +61,6 @@ jobs:
       - name: Run tests with coverage
         run: |
           go test -v -coverprofile=coverage.out ./...
-
-      - name: Run vulnerability check
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-          govulncheck ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -154,27 +168,27 @@ jobs:
 
       - name: '[TEST-NFS] PVC with RWX access mode'
         run: |
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter mount --backend nfs default pvc-1 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter mount --backend nfs default pvc-1 foo
           sudo touch foo/bar-nfs
           ls -l foo/bar-nfs
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter clean --backend nfs default pvc-1 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter clean --backend nfs default pvc-1 foo
 
       - name: '[TEST-NFS] Mounted PVC with RWO access mode'
         run: |
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter mount --backend nfs default pvc-3 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter mount --backend nfs default pvc-3 foo
           sudo touch foo/bar-nfs
           ls -l foo/bar-nfs
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter clean --backend nfs default pvc-3 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter clean --backend nfs default pvc-3 foo
 
       - name: '[TEST-NFS] PVC with RWX access mode (NEEDS_ROOT)'
         run: |
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter mount --backend nfs --needs-root default pvc-4 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter mount --backend nfs --needs-root default pvc-4 foo
           sudo touch foo/bar-nfs
           ls -l foo/bar-nfs
-          sudo KUBECONFIG=$HOME/.kube/config ./bin/pv-mounter clean --backend nfs default pvc-4 foo
+          sudo KUBECONFIG="$HOME/.kube/config" ./bin/pv-mounter clean --backend nfs default pvc-4 foo
 
       - name: Debug NFS pod failure
-        if: failure()
+        if: failure() && steps.minikube.outcome == 'success'
         run: |
           echo "=== Pods ==="
           kubectl get pods -o wide


### PR DESCRIPTION
## Summary
- upgrade govulncheck to v1.7.0 for Go 1.27 compatibility
- run vulnerability scanning once outside the architecture matrix
- keep matrix jobs independent and limit NFS diagnostics to initialized clusters
- quote KUBECONFIG paths to satisfy shell validation

## Verification
- `go test ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...`
- `actionlint .github/workflows/test.yaml`
- GitHub Actions run 32422039802 passed vulnerability-check, amd64, and arm64 jobs